### PR TITLE
Giant overhaul, see PR message for details

### DIFF
--- a/ripl/backend.py
+++ b/ripl/backend.py
@@ -40,7 +40,7 @@ RIPL_TAGS = [
         Tag(r'\'\(.+\)',                            'QUOTED_SEXP'),
         Tag(r'\'.+(?=[\)\]}\s])?',                  'QUOTED_ATOM'),
         Tag(r'`\(.+\)',                             'QUASI_QUOTED'),
-        Tag(r'~\(.+\)',                             'CURRIED_SEXP'),
+        Tag(r'&\(.+\)',                             'CURRIED_SEXP'),
         # Tag(r'\(,.+\)',                             'TUPLE'),
         Tag(r'(\(\)|\s*None)',                      'NULL'),
         # () {} []

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -46,6 +46,22 @@ class LexerTest(TestCase):
         with self.assertRaises(StopIteration):
             token = next(actual_tkns)
 
+    def test_quoting(self):
+        '''quote notation works'''
+        s = "'(i should be quoted!)"
+        tokens = [t.val for t in self.reader.lex(s)]
+        self.assertEqual(
+                tokens,
+                ['(', 'quote', '(', 'i', 'should', 'be', 'quoted!', ')', ')'])
+
+    def test_quasiquoting(self):
+        '''quasiquote notation works'''
+        s = "`(foo bar baz)"
+        tokens = [t.val for t in self.reader.lex(s)]
+        self.assertEqual(
+                tokens,
+                ['(', 'quasiquote', '(', 'foo', 'bar', 'baz', ')', ')'])
+
 
 class ParserTest(TestCase):
     reader = Reader()

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -61,18 +61,6 @@ class EvaluatorTest(TestCase):
         self.assertEqual(result, None)
         self.assertEqual(result, RList())
 
-    def test_quoting_sexp(self):
-        '''Quoting s-expressions works'''
-        string = "'(1 2 3)"
-        result = self._eval(string)
-        self.assertEqual(result, RList([1, 2, 3]))
-
-    def test_quoting_atom(self):
-        '''Quoting atoms works'''
-        string = "'a"
-        result = self._eval(string)
-        self.assertEqual(result, Symbol('a'))
-
     def test_eval_vector(self):
         '''The ([1 2 3] 0) -> 1 syntax works'''
         string = '([1 2 3] 0)'
@@ -96,3 +84,46 @@ class EvaluatorTest(TestCase):
         string = '({1 2, 3 4} 3)'
         result = self._eval(string)
         self.assertEqual(result, 4)
+
+    def test_quoting_sexp(self):
+        '''Quoting s-expressions works'''
+        string = "'(1 2 3)"
+        result = self._eval(string)
+        self.assertEqual(result, RList([1, 2, 3]))
+
+    def test_quoting_atom(self):
+        '''Quoting atoms works'''
+        string = "'a"
+        result = self._eval(string)
+        self.assertEqual(result, Symbol('a'))
+
+    def test_quasiquote_no_unquote(self):
+        '''Quasiquoting with no unquotes is like quoting'''
+        string = "`(1 2 3)"
+        result = self._eval(string)
+        self.assertEqual(result, RList([1, 2, 3]))
+
+    def test_quasiquote_unquote_sexp(self):
+        '''Unquoting s-expressions works'''
+        string = "`(1 2 ~(+ 1 3))"
+        result = self._eval(string)
+        self.assertEqual(result, RList([1, 2, 4]))
+
+    def test_quasiquote_unquotesplice_sexp(self):
+        '''Unquote-splicing s-expressions works'''
+        string = "`(1 2 ~@(1 3))"
+        result = self._eval(string)
+        self.assertEqual(result, RList([1, 2, 1, 3]))
+
+    def test_if(self):
+        '''If expressions work'''
+        s1 = '(if (== 1 2) True False)'
+        s2 = '(if (!= 1 2) True False)'
+        # These two should have an implicit None if False
+        s3 = '(if (== 1 2) True)'
+        s4 = '(if (!= 1 2) True)'
+        expressions = [(s1, False), (s2, True),
+                       (s3, None), (s4, True)]
+        for exp, expected in expressions:
+            result = self._eval(exp)
+            self.assertEqual(result, expected)


### PR DESCRIPTION
Moved built in syntax back to the body of eval and now allow explicit tail call elimination. The evaluator's `syntax` property is now unused but will be used for storing macros once I get those working.
